### PR TITLE
Update kitspace.yaml

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -37,5 +37,3 @@ pcb-services: [aisler, pcbway, oshpark, jlcpcb]
   #      - pcbway
   #      - oshpark
   #      - jlcpcb
-
-multi: # Identifier field only used if the repository contains multiple projects. See below for details.


### PR DESCRIPTION
`multi:` field indicates there are multiple projects but it's empty (so only one project). it's confusing kitspace-v2 ;) 